### PR TITLE
Improve architecture locality

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ macOS is for development and tiny smoke/mock checks only. A macOS run can verify
 The Windows CUDA acceptance workflow is documented in
 [docs/windows-cuda-acceptance.md](docs/windows-cuda-acceptance.md).
 
+The current human verification tracker is documented in
+[docs/manual-verification.md](docs/manual-verification.md).
+
 The Windows 11 + Python 3.12.8 pip-only setup and test workflow is documented in
 [docs/windows-pip-setup.md](docs/windows-pip-setup.md).
 
@@ -66,11 +69,15 @@ Implemented now:
 - Raw Stack metadata records for filename, original index, z position, size, dtype, and XY pixel size
 - PySide6 Open Folder flow for loading a Raw Stack into the UI
 - Natural file order and physical spacing summary in the UI
+- Project summary formatting is concentrated in a dedicated module
 - 2D raw slice viewer with slider navigation
+- 2D image display scaling and QLabel rendering are concentrated in a dedicated ImageView module
 - Raw XY / XZ / YZ Orthogonal Preview generation and display
 - Threshold histogram statistics for loaded Raw Stacks in original uint8 /
   uint16 intensity units
 - Otsu default threshold selection after Raw Stack load
+- Threshold pending/applied state and summary formatting are concentrated in
+  the threshold module
 - Threshold slider, numeric input, and Apply / Enter behavior for committing
   an applied threshold without rebuilding while dragging
 - VTK + Qt 3D preview rendering shell in the main preview area
@@ -85,7 +92,10 @@ Implemented now:
   Iso-surface Preview shell, and right lower supporting Orthogonal Preview
 - Identity Preview Stack export from the loaded Raw Stack
 - Identity export metadata JSON with input mapping, slice provenance, dimensions, dtype, software version, and identity alignment status
+- Preview Stack metadata generation is concentrated in a dedicated module separate from TIFF file writing
 - Phase-correlation-only Preview Alignment as a degraded/debug path
+- Phase-only alignment, pairwise phase edge creation, and global graph solving
+  are concentrated in a dedicated phase alignment module
 - Pairwise phase correlation edges for slice distances 1 to 3 with dx, dy, response, weight, and method metadata
 - Weighted registration graph solve for non-cumulative global coarse XY positions
 - Robust graph solve now ignores very low-confidence phase edges so isolated
@@ -96,13 +106,18 @@ Implemented now:
 - Phase-only export metadata records the Aligned Crop Region and cropped output dimensions
 - RAFT input foundation with stack-level robust range normalization, grayscale-to-3-channel tensor conversion, reflect padding, crop-back, and a mock smoke backend for development
 - RAFT smoke metadata records normalization range, backend name, device/degraded mode, and padding behavior
+- RAFT input provenance generation is concentrated in the RAFT module
 - Optional real RAFT adapter using `torchvision.models.optical_flow`
 - RAFT backend selection through `ALIGNER_RAFT_BACKEND=mock|torchvision|auto`
+- RAFT backend selection and fallback rules are concentrated in the RAFT module
 - Constrained RAFT local alignment MVS using small/mock RAFT flow inputs
 - Balanced constrained flow parameters fixed at max displacement 4 px, 64 px control grid spacing, smoothing sigma 1 grid cell, and working scale 1.0
 - Run Alignment now executes phase correlation followed by constrained RAFT local alignment and shows the constrained RAFT Aligned Stack in the Orthogonal Preview panel
+- User-visible app status message formatting is concentrated in a dedicated module
 - Constrained RAFT Preview Stack export metadata records RAFT backend, degraded mode, working resolution scale, RAFT normalization range, RAFT Padding/crop-back provenance, Balanced constraint parameters, control grid shape, and raw/constrained flow displacement maxima
 - Internal Bad Slice detection and preview-only replacement MVS
+- Bad Slice marking, Alignment-Unusable confirmation, and preview-only
+  replacement are concentrated in a dedicated module for local rule changes
 - Phase graph confidence can mark suspicious slices without replacing normal
   slices that merely have low absolute response values
 - RAFT/control-grid sanity is required before a suspicious slice becomes Alignment-Unusable
@@ -114,20 +129,30 @@ Implemented now:
 - Preview Stack export metadata records per-slice output dimensions, Bad Slice status, display source, and replacement source slices
 - Basic tests for discovery, sorting, and unit conversion
 - Behavior tests for Raw Stack loading validation and Orthogonal Preview generation
+- Focused behavior tests for Project summary formatting
+- Focused behavior tests for 2D image display scaling
 - Behavior tests for 8-bit / 16-bit Raw Stack loading, provenance fields, unsupported input errors, UI slice spacing input, TIFF XY pixel size metadata, manual XY fallback, and UI XY summary
 - Behavior tests for threshold histograms, Otsu defaults, pending threshold
   edits, and explicit Apply / Enter threshold commits
+- Focused behavior tests for threshold pending/applied state and summary text
 - Behavior tests for Raw Stack threshold iso-surface preview volume spacing,
   display-only non-mutation behavior, and applied-threshold preview rebuilds
 - Behavior tests for Raw and Aligned Stack 3D preview source labeling,
   Run Alignment preview refresh, and active-stack threshold rebuild behavior
+- Focused behavior tests for user-visible app status messages
 - Behavior tests for identity TIFF export, metadata fields, overwrite refusal, and UI export enablement
+- Focused behavior tests for Preview Stack metadata generation without filesystem side effects
 - Behavior tests verifying Threshold Iso-surface Preview state does not affect
   Raw or Aligned Stack Preview Stack export files or metadata
 - Behavior tests for phase correlation edge creation, graph solving, phase-only aligned stack generation, UI alignment, phase-only export metadata, and common crop export dimensions
+- Phase alignment module remains re-exported through the alignment module for
+  backward-compatible callers
 - Behavior tests for RAFT normalization consistency, tensor conversion shape, reflect padding, crop-back, and mock smoke metadata
+- Behavior tests for RAFT input provenance generation
+- Behavior tests for RAFT backend selection through the RAFT module interface
 - Behavior tests for constrained flow clipping, constrained flow shape, local preview warp integration, UI Run Alignment, and constrained RAFT export metadata
 - Behavior tests for two-stage Bad Slice confirmation, no replacement on phase signal alone, preview-only replacement provenance, preserved slice rhythm, Bad Slice export metadata, complete RAFT input provenance export, and final aligned TIFF export contract
+- Focused behavior tests for the Bad Slice rule module interface
 
 Not implemented yet:
 
@@ -135,13 +160,15 @@ Not implemented yet:
 
 Current acceptance status:
 
+- Remaining human verification is summarized in
+  [docs/manual-verification.md](docs/manual-verification.md).
 - 600-slice Threshold Iso-surface Preview acceptance is tracked in
   [Issue #22](https://github.com/LesterCtw/Aligner/issues/22). Automated
   behavior coverage exists for threshold controls, Raw/Aligned preview source
   switching, and export isolation. The manual camera interaction acceptance
   remains pending on a real desktop display with a practical 600-slice stack.
 - Real RAFT implementation work is tracked in
-  [#13](https://github.com/LesterCtw/Aligner/issues/13).
+  [#13](https://github.com/LesterCtw/Aligner/issues/13), which is closed.
 - Final Windows CUDA acceptance remains tracked in
   [#12](https://github.com/LesterCtw/Aligner/issues/12).
 - macOS cannot verify CUDA execution. The remaining required check is to run

--- a/docs/manual-verification.md
+++ b/docs/manual-verification.md
@@ -1,0 +1,72 @@
+# Manual Verification Tracker
+
+This document collects the current human verification work. `README.md`
+remains the source of truth for project status after each verification run.
+
+Last checked against GitHub issues: 2026-05-04.
+
+## Goal
+
+Keep the remaining manual checks visible in one place:
+
+- which GitHub issue owns the check
+- what environment is required
+- what result must be recorded back into `README.md`
+
+## Known Constraints
+
+- Full v1 acceptance requires Windows 11 with an NVIDIA CUDA GPU.
+- macOS can verify development smoke paths only. It cannot verify CUDA
+  execution or full v1 acceptance.
+- Manual verification needs a representative TIFF Raw Stack. The 600-slice
+  preview check needs a practical stack with at least 600 slices.
+- Automated tests do not replace the manual camera, display, CUDA, and export
+  inspection checks.
+
+## Current Assumptions
+
+- The user or maintainer can provide the target Windows CUDA machine.
+- The user or maintainer can provide representative Raw Stack data.
+- Acceptance results should be recorded factually, including failed or degraded
+  runs.
+
+## Unverified Or Unclear
+
+- Exact Windows machine, GPU model, and CUDA wheel versions are not recorded
+  yet.
+- Exact representative Raw Stack path and summary are not recorded yet.
+- 600-slice interactive camera performance has not been verified on a real
+  desktop display.
+
+## Ready For Human Issues
+
+| Issue | Scope | Required environment | What to record |
+| --- | --- | --- | --- |
+| [#1 PRD: Aligner v1 Preview Alignment MVS](https://github.com/LesterCtw/Aligner/issues/1) | Overall v1 Preview Alignment acceptance umbrella. Confirms the product goal is satisfied end to end, not only through automated tests. | Windows 11 + NVIDIA CUDA GPU for full acceptance. | Final v1 acceptance status, remaining caveats, and any degraded-mode notes in `README.md`. |
+| [#12 Windows CUDA v1 acceptance workflow](https://github.com/LesterCtw/Aligner/issues/12) | Run the complete Windows CUDA workflow: install, launch, load Raw Stack, inspect raw preview, run real RAFT, inspect aligned preview, export TIFFs and metadata. | Windows 11 + NVIDIA CUDA GPU with real `torchvision.models.optical_flow` RAFT selected. | Windows version, GPU, Python, `torch`, `torchvision`, CUDA availability, Raw Stack summary, pass/fail result, export inspection notes. |
+| [#22 End-to-end 600-slice preview acceptance smoke path](https://github.com/LesterCtw/Aligner/issues/22) | Verify the Threshold Iso-surface Preview with at least 600 slices, including threshold controls and 3D camera interaction. | Real desktop display with a practical 600-slice Raw Stack. CUDA is needed if this also includes Run Alignment with real RAFT. | Stack summary, threshold behavior, camera rotate/zoom/pan usability, Raw/Aligned preview refresh result, performance caveats. |
+
+## Related Umbrella Issue
+
+| Issue | Relationship |
+| --- | --- |
+| [#14 PRD: 3D Threshold Iso-surface Preview](https://github.com/LesterCtw/Aligner/issues/14) | Umbrella PRD for the 3D Threshold Iso-surface Preview. Issue #22 is the human acceptance smoke path for this feature. |
+
+## Existing Workflow Docs
+
+- Full Windows CUDA acceptance steps:
+  [windows-cuda-acceptance.md](windows-cuda-acceptance.md)
+- Windows pip-only setup steps:
+  [windows-pip-setup.md](windows-pip-setup.md)
+
+## Minimum Verification Order
+
+1. Run the setup and pre-checks from
+   [windows-cuda-acceptance.md](windows-cuda-acceptance.md).
+2. Complete #12 on the Windows CUDA target.
+3. Complete #22 with a practical 600-slice stack.
+4. Update `README.md` with factual pass/fail results and environment notes.
+5. Close or comment on the relevant GitHub issues with the same evidence.
+
+This order is the simplest path because #12 confirms the full RAFT acceptance
+environment first, then #22 focuses on interactive 3D preview usability.

--- a/src/aligner/alignment.py
+++ b/src/aligner/alignment.py
@@ -1,56 +1,39 @@
 from __future__ import annotations
 
-import os
-from dataclasses import replace
-
 import numpy as np
 from numpy.typing import NDArray
 from scipy.ndimage import map_coordinates
 
+from aligner.bad_slices import (
+    RAFT_UNUSABLE_RAW_DISPLACEMENT_MULTIPLIER,
+    replace_alignment_unusable_slices,
+)
 from aligner.models import (
-    AlignedCropRegion,
     AlignedStack,
     ConstrainedRaftAlignmentMetadata,
-    PairwiseEdge,
     RaftConstraintParameters,
     RawStack,
-    SliceRecord,
+)
+from aligner.phase_alignment import (
+    create_phase_correlation_edges,
+    run_phase_alignment,
+    solve_global_positions,
 )
 from aligner.raft import (
     BALANCED_RAFT_CONSTRAINTS,
-    RaftAdapterMetadata,
     RaftFlowResult,
-    TorchvisionRaftUnavailableError,
     constrain_raft_flow,
-    run_mock_raft_smoke_path,
-    run_torchvision_raft_flow,
+    raft_input_provenance,
+    select_raft_flow_provider,
 )
 
 
-PHASE_SUSPICIOUS_RESPONSE_THRESHOLD = 0.02
-PHASE_OUTLIER_RESPONSE_RATIO = 0.25
-PHASE_BRIDGE_CONFIRMATION_RATIO = 5.0
-RAFT_UNUSABLE_RAW_DISPLACEMENT_MULTIPLIER = 2.0
-
-
-def run_phase_alignment(stack: RawStack, *, max_pair_distance: int = 3) -> AlignedStack:
-    edges = create_phase_correlation_edges(stack, max_pair_distance=max_pair_distance)
-    positions = solve_global_positions(edges, slice_count=stack.data.shape[0])
-    data = _apply_integer_alignment(stack.data, positions)
-    height, width = stack.data.shape[1:]
-    return AlignedStack(
-        data=data,
-        slices=_mark_phase_suspicious_slices(stack.slices, edges),
-        slice_spacing_nm=stack.slice_spacing_nm,
-        edges=edges,
-        positions=positions,
-        crop_region=_compute_common_valid_crop_region(
-            positions,
-            width=width,
-            height=height,
-        ),
-        xy_pixel_size_nm=stack.xy_pixel_size_nm,
-    )
+__all__ = [
+    "create_phase_correlation_edges",
+    "run_constrained_raft_alignment",
+    "run_phase_alignment",
+    "solve_global_positions",
+]
 
 
 def run_constrained_raft_alignment(
@@ -85,7 +68,7 @@ def run_constrained_raft_alignment(
             ),
         )
 
-    provider = raft_flow_provider or _select_default_raft_flow_provider()
+    provider = raft_flow_provider or select_raft_flow_provider()
     local_stack = RawStack(
         data=phase_aligned.data,
         slices=phase_aligned.slices,
@@ -111,7 +94,7 @@ def run_constrained_raft_alignment(
             device = flow_result.metadata.device
             degraded_mode = flow_result.metadata.degraded_mode
             if raft_input is None:
-                raft_input = _raft_input_provenance(flow_result.metadata)
+                raft_input = raft_input_provenance(flow_result.metadata)
         else:
             raw_flow = flow_result
 
@@ -131,7 +114,7 @@ def run_constrained_raft_alignment(
         control_grid_shape = constrained_flow.metadata.control_grid_shape
         flow_count += 1
 
-    locally_aligned, slices = _replace_confirmed_bad_slices(
+    locally_aligned, slices = replace_alignment_unusable_slices(
         locally_aligned,
         phase_aligned.data,
         phase_aligned.slices,
@@ -164,338 +147,7 @@ def run_constrained_raft_alignment(
             control_grid_shape=control_grid_shape,
             raft_input=raft_input,
         ),
-    )
-
-
-def _raft_input_provenance(metadata: RaftAdapterMetadata) -> dict[str, object]:
-    return {
-        "normalization": {
-            "source_min": metadata.normalization.source_min,
-            "source_max": metadata.normalization.source_max,
-            "lower_percentile": metadata.normalization.lower_percentile,
-            "upper_percentile": metadata.normalization.upper_percentile,
-        },
-        "padding": {
-            "mode": metadata.padding.mode,
-            "multiple": metadata.padding.multiple,
-            "original_width": metadata.padding.original_width,
-            "original_height": metadata.padding.original_height,
-            "padded_width": metadata.padding.padded_width,
-            "padded_height": metadata.padding.padded_height,
-            "pad_left": metadata.padding.pad_left,
-            "pad_right": metadata.padding.pad_right,
-            "pad_top": metadata.padding.pad_top,
-            "pad_bottom": metadata.padding.pad_bottom,
-        },
-        "crop_back": {
-            "x": metadata.crop_x,
-            "y": metadata.crop_y,
-            "width": metadata.crop_width,
-            "height": metadata.crop_height,
-        },
-    }
-
-
-def create_phase_correlation_edges(
-    stack: RawStack,
-    *,
-    max_pair_distance: int = 3,
-) -> list[PairwiseEdge]:
-    edges: list[PairwiseEdge] = []
-    slice_count = stack.data.shape[0]
-    for distance in range(1, max_pair_distance + 1):
-        for i in range(0, slice_count - distance):
-            j = i + distance
-            dx, dy, response = _estimate_integer_shift(stack.data[i], stack.data[j])
-            edges.append(
-                PairwiseEdge(
-                    i=i,
-                    j=j,
-                    dx=dx,
-                    dy=dy,
-                    response=response,
-                    weight=response,
-                    method="phase_correlation",
-                )
-            )
-    return edges
-
-
-def solve_global_positions(
-    edges: list[PairwiseEdge],
-    *,
-    slice_count: int,
-) -> list[tuple[float, float]]:
-    if slice_count <= 0:
-        return []
-    if slice_count == 1 or not edges:
-        return [(0.0, 0.0) for _ in range(slice_count)]
-
-    x = _solve_axis(edges, slice_count=slice_count, axis="x")
-    y = _solve_axis(edges, slice_count=slice_count, axis="y")
-    return list(zip(x, y, strict=True))
-
-
-def _solve_axis(edges: list[PairwiseEdge], *, slice_count: int, axis: str) -> list[float]:
-    variable_count = slice_count - 1
-    rows: list[np.ndarray] = []
-    values: list[float] = []
-    response_floor = _phase_response_floor(edges)
-
-    for edge in edges:
-        if _is_low_confidence_phase_edge(edge, response_floor):
-            continue
-        weight = float(np.sqrt(max(edge.weight, 0.0)))
-        if weight == 0.0:
-            continue
-
-        row = np.zeros(variable_count, dtype=np.float64)
-        if edge.i > 0:
-            row[edge.i - 1] -= weight
-        if edge.j > 0:
-            row[edge.j - 1] += weight
-
-        rows.append(row)
-        values.append((edge.dx if axis == "x" else edge.dy) * weight)
-
-    if not rows:
-        return [0.0 for _ in range(slice_count)]
-
-    solution, *_ = np.linalg.lstsq(np.vstack(rows), np.array(values), rcond=None)
-    return [0.0, *[float(value) for value in solution]]
-
-
-def _apply_integer_alignment(
-    data: NDArray[np.integer],
-    positions: list[tuple[float, float]],
-) -> NDArray[np.integer]:
-    aligned = np.empty_like(data)
-    for index, (dx, dy) in enumerate(positions):
-        aligned[index] = np.roll(
-            data[index],
-            shift=(-int(round(dy)), -int(round(dx))),
-            axis=(0, 1),
-        )
-    return aligned
-
-
-def _mark_phase_suspicious_slices(
-    slices: list[SliceRecord],
-    edges: list[PairwiseEdge],
-) -> list[SliceRecord]:
-    output = [replace(record) for record in slices]
-    response_floor = _phase_response_floor(edges)
-    adjacent_responses = {
-        (edge.i, edge.j): edge.response
-        for edge in edges
-        if edge.j == edge.i + 1
-    }
-
-    for index in range(1, len(output) - 1):
-        left_response = adjacent_responses.get((index - 1, index))
-        right_response = adjacent_responses.get((index, index + 1))
-        if (
-            left_response is not None
-            and right_response is not None
-            and (
-                (
-                    left_response < response_floor
-                    and right_response < response_floor
-                )
-                or _has_phase_bridge_confirmation(index, edges)
-            )
-        ):
-            output[index].quality_label = "suspicious"
-
-    return output
-
-
-def _replace_confirmed_bad_slices(
-    data: NDArray[np.integer],
-    replacement_source_data: NDArray[np.integer],
-    slices: list[SliceRecord],
-    raft_pair_raw_max: dict[tuple[int, int], float],
-    edges: list[PairwiseEdge],
-    *,
-    raw_displacement_threshold: float,
-    allow_phase_bridge_confirmation: bool,
-) -> tuple[NDArray[np.integer], list[SliceRecord]]:
-    output_data = np.array(data, copy=True)
-    output_slices = [replace(record) for record in slices]
-
-    for index in range(1, len(output_slices) - 1):
-        if output_slices[index].quality_label != "suspicious":
-            continue
-
-        left_raw_max = raft_pair_raw_max.get((index - 1, index), 0.0)
-        right_raw_max = raft_pair_raw_max.get((index, index + 1), 0.0)
-        raft_confirmed = (
-            left_raw_max > raw_displacement_threshold
-            and right_raw_max > raw_displacement_threshold
-        )
-        phase_confirmed = (
-            allow_phase_bridge_confirmation
-            and _has_phase_bridge_confirmation(index, edges)
-        )
-        if not raft_confirmed and not phase_confirmed:
-            continue
-
-        left_index = index - 1
-        right_index = index + 1
-        output_data[left_index] = replacement_source_data[left_index]
-        output_data[right_index] = replacement_source_data[right_index]
-        interpolated = (
-            replacement_source_data[left_index].astype(np.float32)
-            + replacement_source_data[right_index].astype(np.float32)
-        ) / 2.0
-        output_data[index] = np.rint(interpolated).astype(output_data.dtype)
-        output_slices[index].quality_label = "alignment_unusable"
-        output_slices[index].display_source = "interpolated"
-        output_slices[index].interpolated_from = (
-            output_slices[left_index].index,
-            output_slices[right_index].index,
-        )
-
-    return output_data, output_slices
-
-
-def _phase_response_floor(edges: list[PairwiseEdge]) -> float:
-    adjacent_responses = [
-        edge.response
-        for edge in edges
-        if edge.method == "phase_correlation" and edge.j == edge.i + 1 and edge.response > 0
-    ]
-    if not adjacent_responses:
-        return PHASE_SUSPICIOUS_RESPONSE_THRESHOLD
-    return float(np.median(adjacent_responses) * PHASE_OUTLIER_RESPONSE_RATIO)
-
-
-def _is_low_confidence_phase_edge(edge: PairwiseEdge, response_floor: float) -> bool:
-    return edge.method == "phase_correlation" and edge.response < response_floor
-
-
-def _has_phase_bridge_confirmation(index: int, edges: list[PairwiseEdge]) -> bool:
-    left = _edge_response(edges, index - 1, index)
-    right = _edge_response(edges, index, index + 1)
-    bridge = _edge_response(edges, index - 1, index + 1)
-    if left is None or right is None or bridge is None:
-        return False
-
-    strongest_adjacent = max(left, right)
-    return (
-        bridge > 0
-        and strongest_adjacent > 0
-        and bridge >= strongest_adjacent * PHASE_BRIDGE_CONFIRMATION_RATIO
-    )
-
-
-def _edge_response(edges: list[PairwiseEdge], i: int, j: int) -> float | None:
-    for edge in edges:
-        if edge.i == i and edge.j == j:
-            return edge.response
-    return None
-
-
-def _compute_common_valid_crop_region(
-    positions: list[tuple[float, float]],
-    *,
-    width: int,
-    height: int,
-) -> AlignedCropRegion:
-    left = 0
-    top = 0
-    right = width
-    bottom = height
-
-    for dx, dy in positions:
-        x = int(round(dx))
-        y = int(round(dy))
-        left = max(left, 0 if x >= 0 else -x)
-        top = max(top, 0 if y >= 0 else -y)
-        right = min(right, width - x if x >= 0 else width)
-        bottom = min(bottom, height - y if y >= 0 else height)
-
-    if right <= left or bottom <= top:
-        raise ValueError("Alignment transforms have no common valid crop region.")
-
-    return AlignedCropRegion(
-        x=left,
-        y=top,
-        width=right - left,
-        height=bottom - top,
-    )
-
-
-def _estimate_integer_shift(
-    reference: NDArray[np.integer],
-    moving: NDArray[np.integer],
-) -> tuple[float, float, float]:
-    reference_fft = np.fft.fft2(reference.astype(np.float32))
-    moving_fft = np.fft.fft2(moving.astype(np.float32))
-    cross_power = moving_fft * np.conj(reference_fft)
-    magnitude = np.abs(cross_power)
-    cross_power = np.divide(
-        cross_power,
-        magnitude,
-        out=np.zeros_like(cross_power),
-        where=magnitude > 0,
-    )
-    correlation = np.abs(np.fft.ifft2(cross_power))
-    peak_y, peak_x = np.unravel_index(np.argmax(correlation), correlation.shape)
-
-    height, width = reference.shape
-    dy = peak_y - height if peak_y > height // 2 else peak_y
-    dx = peak_x - width if peak_x > width // 2 else peak_x
-    response = float(correlation[peak_y, peak_x] / np.sum(correlation))
-    return float(dx), float(dy), response
-
-
-def _run_mock_raft_flow(
-    stack: RawStack,
-    reference_index: int,
-    moving_index: int,
-) -> RaftFlowResult:
-    return run_mock_raft_smoke_path(
-        stack,
-        reference_index=reference_index,
-        moving_index=moving_index,
-    )
-
-
-def _run_torchvision_raft_flow(
-    stack: RawStack,
-    reference_index: int,
-    moving_index: int,
-) -> RaftFlowResult:
-    return run_torchvision_raft_flow(
-        stack,
-        reference_index=reference_index,
-        moving_index=moving_index,
-    )
-
-
-def _select_default_raft_flow_provider():
-    backend = os.environ.get("ALIGNER_RAFT_BACKEND", "mock").strip().lower()
-    if backend in {"mock", "mock_raft", "degraded"}:
-        return _run_mock_raft_flow
-    if backend in {"torchvision", "real", "cuda"}:
-        return _run_torchvision_raft_flow
-    if backend == "auto":
-        return _run_auto_raft_flow
-    raise ValueError(
-        "ALIGNER_RAFT_BACKEND must be one of: mock, torchvision, auto."
-    )
-
-
-def _run_auto_raft_flow(
-    stack: RawStack,
-    reference_index: int,
-    moving_index: int,
-) -> RaftFlowResult:
-    try:
-        return _run_torchvision_raft_flow(stack, reference_index, moving_index)
-    except TorchvisionRaftUnavailableError:
-        return _run_mock_raft_flow(stack, reference_index, moving_index)
+)
 
 
 def _warp_image_with_flow(

--- a/src/aligner/app.py
+++ b/src/aligner/app.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import numpy as np
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -25,7 +23,14 @@ from PySide6.QtWidgets import (
 
 from aligner.alignment import run_constrained_raft_alignment
 from aligner.app_icon import load_application_icon
+from aligner.app_messages import (
+    alignment_success_message,
+    export_success_message,
+    load_success_message,
+    show_slice_message,
+)
 from aligner.export import export_preview_stack
+from aligner.image_view import ImageView
 from aligner.io import load_raw_stack, spacing_to_nm
 from aligner.models import AlignedStack, ProjectConfig, RawStack
 from aligner.preview import (
@@ -33,53 +38,13 @@ from aligner.preview import (
     generate_orthogonal_previews,
     generate_threshold_preview_volume,
 )
-from aligner.threshold import ThresholdStatistics, compute_threshold_statistics
+from aligner.project_summary import format_project_summary
+from aligner.threshold import (
+    ThresholdControlState,
+    compute_threshold_statistics,
+    format_threshold_summary,
+)
 from aligner.vtk_preview import ThresholdIsoSurfacePreview
-
-
-def _array_to_display_uint8(array: np.ndarray) -> np.ndarray:
-    if array.dtype == np.uint8:
-        return np.ascontiguousarray(array)
-
-    min_value = float(np.min(array))
-    max_value = float(np.max(array))
-    if max_value <= min_value:
-        return np.zeros(array.shape, dtype=np.uint8)
-
-    scaled = (array.astype(np.float32) - min_value) * (255.0 / (max_value - min_value))
-    return np.ascontiguousarray(np.clip(scaled, 0, 255).astype(np.uint8))
-
-
-def _array_to_pixmap(array: np.ndarray) -> QPixmap:
-    display = _array_to_display_uint8(array)
-    height, width = display.shape
-    image = QImage(
-        display.data,
-        width,
-        height,
-        display.strides[0],
-        QImage.Format.Format_Grayscale8,
-    ).copy()
-    return QPixmap.fromImage(image)
-
-
-class ImageView(QLabel):
-    def __init__(self, title: str) -> None:
-        super().__init__(title)
-        self._title = title
-        self.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.setMinimumSize(180, 140)
-        self.setStyleSheet("background: #202124; color: #f1f3f4;")
-
-    def show_array(self, array: np.ndarray) -> None:
-        pixmap = _array_to_pixmap(array)
-        self.setPixmap(
-            pixmap.scaled(
-                self.size(),
-                Qt.AspectRatioMode.KeepAspectRatio,
-                Qt.TransformationMode.SmoothTransformation,
-            )
-        )
 
 
 class MainWindow(QMainWindow):
@@ -94,10 +59,7 @@ class MainWindow(QMainWindow):
         self.raw_stack: RawStack | None = None
         self.aligned_stack: AlignedStack | None = None
         self.threshold_preview_volume: ThresholdPreviewVolume | None = None
-        self.threshold_statistics: ThresholdStatistics | None = None
-        self.pending_threshold: int | None = None
-        self.applied_threshold: int | None = None
-        self.applied_threshold_rebuilds: list[int] = []
+        self.threshold_state = ThresholdControlState.unavailable()
         self._syncing_threshold_controls = False
 
         toolbar = QToolBar("Main")
@@ -246,9 +208,7 @@ class MainWindow(QMainWindow):
         self.export_button.setEnabled(True)
         self._update_stack_summary()
         self.show_slice(0)
-        self.statusBar().showMessage(
-            f"Loaded {len(self.raw_stack.slices)} raw slices; 3D preview: Raw Stack"
-        )
+        self.statusBar().showMessage(load_success_message(len(self.raw_stack.slices)))
 
     def run_alignment(self) -> None:
         if self.raw_stack is None:
@@ -261,7 +221,7 @@ class MainWindow(QMainWindow):
         )
         self._prepare_active_stack_iso_surface_preview()
         self.show_slice(self.timeline.value())
-        self.statusBar().showMessage("Generated constrained RAFT Aligned Stack; 3D preview: Aligned Stack")
+        self.statusBar().showMessage(alignment_success_message())
 
     def export_preview_stack(self) -> None:
         if self.raw_stack is None:
@@ -285,14 +245,7 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage(f"Export failed: {error}")
             return
 
-        export_label = "identity"
-        if self.aligned_stack is not None:
-            export_label = (
-                "constrained RAFT"
-                if self.aligned_stack.alignment_status == "constrained_raft"
-                else "phase-only"
-            )
-        self.statusBar().showMessage(f"Exported {export_label} Preview Stack to {folder}")
+        self.statusBar().showMessage(export_success_message(self.aligned_stack, folder))
 
     def show_slice(self, slice_index: int) -> None:
         if self.raw_stack is None:
@@ -304,28 +257,33 @@ class MainWindow(QMainWindow):
         self.xy_preview.show_array(previews.xy)
         self.xz_preview.show_array(previews.xz)
         self.yz_preview.show_array(previews.yz)
-        stack_label = "aligned" if self.aligned_stack is not None else "raw"
         self.statusBar().showMessage(
-            f"Showing {stack_label} slice {slice_index + 1} of {len(self.raw_stack.slices)}"
+            show_slice_message(
+                aligned=self.aligned_stack is not None,
+                slice_index=slice_index,
+                slice_count=len(self.raw_stack.slices),
+            )
         )
 
     def apply_threshold(self) -> None:
-        if self.pending_threshold is None:
+        applied_threshold = self.threshold_state.apply_pending()
+        if applied_threshold is None:
             return
 
-        self.applied_threshold = self.pending_threshold
-        self.applied_threshold_rebuilds.append(self.applied_threshold)
         self._render_active_stack_iso_surface_preview()
-        self.statusBar().showMessage(f"Applied threshold {self.applied_threshold}")
+        self.statusBar().showMessage(f"Applied threshold {applied_threshold}")
 
     def _prepare_threshold_controls(self) -> None:
         if self.raw_stack is None:
             self._reset_threshold_controls()
             return
 
-        self.threshold_statistics = compute_threshold_statistics(self.raw_stack.data)
-        threshold = self.threshold_statistics.otsu_threshold
-        max_intensity = int(self.threshold_statistics.intensity_values[-1])
+        statistics = compute_threshold_statistics(self.raw_stack.data)
+        self.threshold_state = ThresholdControlState.from_statistics(statistics)
+        threshold = self.threshold_state.pending_threshold
+        if threshold is None:
+            return
+        max_intensity = int(statistics.intensity_values[-1])
 
         self._syncing_threshold_controls = True
         try:
@@ -336,19 +294,13 @@ class MainWindow(QMainWindow):
         finally:
             self._syncing_threshold_controls = False
 
-        self.pending_threshold = threshold
-        self.applied_threshold = threshold
-        self.applied_threshold_rebuilds = [threshold]
         self.threshold_slider.setEnabled(True)
         self.threshold_value.setEnabled(True)
         self.apply_threshold_button.setEnabled(True)
-        self.threshold_summary.setText(self._format_threshold_summary(self.threshold_statistics))
+        self.threshold_summary.setText(format_threshold_summary(statistics))
 
     def _reset_threshold_controls(self) -> None:
-        self.threshold_statistics = None
-        self.pending_threshold = None
-        self.applied_threshold = None
-        self.applied_threshold_rebuilds = []
+        self.threshold_state = ThresholdControlState.unavailable()
 
         self._syncing_threshold_controls = True
         try:
@@ -407,7 +359,7 @@ class MainWindow(QMainWindow):
         if self._syncing_threshold_controls:
             return
 
-        self.pending_threshold = value
+        self.threshold_state.set_pending(value)
         self._syncing_threshold_controls = True
         try:
             self.threshold_value.setValue(value)
@@ -418,44 +370,39 @@ class MainWindow(QMainWindow):
         if self._syncing_threshold_controls:
             return
 
-        self.pending_threshold = value
+        self.threshold_state.set_pending(value)
         self._syncing_threshold_controls = True
         try:
             self.threshold_slider.setValue(value)
         finally:
             self._syncing_threshold_controls = False
 
-    def _format_threshold_summary(self, statistics: ThresholdStatistics) -> str:
-        occupied = np.flatnonzero(statistics.histogram_counts)
-        min_intensity = int(statistics.intensity_values[occupied[0]])
-        max_intensity = int(statistics.intensity_values[occupied[-1]])
-        voxel_count = int(statistics.histogram_counts.sum())
-        return (
-            f"Histogram: {voxel_count} voxels, intensity {min_intensity:g}-{max_intensity:g}; "
-            f"Otsu threshold: {statistics.otsu_threshold:g}"
-        )
-
     def _update_stack_summary(self) -> None:
         if self.raw_stack is None:
             return
 
-        files = [record.filename for record in self.raw_stack.slices]
-        preview_names = files[:8]
-        if len(files) > len(preview_names):
-            preview_names.append(f"... {len(files) - len(preview_names)} more")
-
-        first = self.raw_stack.slices[0]
         self.left_panel.setText(
-            "Project settings\n\n"
-            f"Folder: {self.config.input_folder}\n"
-            f"Slices: {len(self.raw_stack.slices)}\n"
-            f"Size: {first.width} x {first.height}\n"
-            f"Dtype: {first.dtype}\n"
-            f"Slice spacing: {self.raw_stack.slice_spacing_nm:g} nm\n"
-            f"XY pixel size: {self.raw_stack.xy_pixel_size_nm:g} nm\n\n"
-            "Natural file order:\n"
-            + "\n".join(preview_names)
+            format_project_summary(
+                self.raw_stack,
+                input_folder=self.config.input_folder,
+            )
         )
+
+    @property
+    def threshold_statistics(self):
+        return self.threshold_state.statistics
+
+    @property
+    def pending_threshold(self) -> int | None:
+        return self.threshold_state.pending_threshold
+
+    @property
+    def applied_threshold(self) -> int | None:
+        return self.threshold_state.applied_threshold
+
+    @property
+    def applied_threshold_rebuilds(self) -> list[int]:
+        return self.threshold_state.applied_threshold_rebuilds
 
 
 def run_gui() -> int:

--- a/src/aligner/app_messages.py
+++ b/src/aligner/app_messages.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from aligner.models import AlignedStack
+
+
+def load_success_message(slice_count: int) -> str:
+    return f"Loaded {slice_count} raw slices; 3D preview: Raw Stack"
+
+
+def alignment_success_message() -> str:
+    return "Generated constrained RAFT Aligned Stack; 3D preview: Aligned Stack"
+
+
+def export_success_message(stack: AlignedStack | None, folder: object) -> str:
+    return f"Exported {export_label(stack)} Preview Stack to {folder}"
+
+
+def export_label(stack: AlignedStack | None) -> str:
+    if stack is None:
+        return "identity"
+    if stack.alignment_status == "constrained_raft":
+        return "constrained RAFT"
+    return "phase-only"
+
+
+def show_slice_message(
+    *,
+    aligned: bool,
+    slice_index: int,
+    slice_count: int,
+) -> str:
+    stack_label = "aligned" if aligned else "raw"
+    return f"Showing {stack_label} slice {slice_index + 1} of {slice_count}"

--- a/src/aligner/bad_slices.py
+++ b/src/aligner/bad_slices.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+from numpy.typing import NDArray
+
+from aligner.models import PairwiseEdge, SliceRecord
+
+
+PHASE_SUSPICIOUS_RESPONSE_THRESHOLD = 0.02
+PHASE_OUTLIER_RESPONSE_RATIO = 0.25
+PHASE_BRIDGE_CONFIRMATION_RATIO = 5.0
+RAFT_UNUSABLE_RAW_DISPLACEMENT_MULTIPLIER = 2.0
+
+
+def mark_phase_suspicious_slices(
+    slices: list[SliceRecord],
+    edges: list[PairwiseEdge],
+) -> list[SliceRecord]:
+    output = [replace(record) for record in slices]
+    response_floor = phase_response_floor(edges)
+    adjacent_responses = {
+        (edge.i, edge.j): edge.response
+        for edge in edges
+        if edge.j == edge.i + 1
+    }
+
+    for index in range(1, len(output) - 1):
+        left_response = adjacent_responses.get((index - 1, index))
+        right_response = adjacent_responses.get((index, index + 1))
+        if (
+            left_response is not None
+            and right_response is not None
+            and (
+                (
+                    left_response < response_floor
+                    and right_response < response_floor
+                )
+                or has_phase_bridge_confirmation(index, edges)
+            )
+        ):
+            output[index].quality_label = "suspicious"
+
+    return output
+
+
+def replace_alignment_unusable_slices(
+    data: NDArray[np.integer],
+    replacement_source_data: NDArray[np.integer],
+    slices: list[SliceRecord],
+    raft_pair_raw_max: dict[tuple[int, int], float],
+    edges: list[PairwiseEdge],
+    *,
+    raw_displacement_threshold: float,
+    allow_phase_bridge_confirmation: bool,
+) -> tuple[NDArray[np.integer], list[SliceRecord]]:
+    output_data = np.array(data, copy=True)
+    output_slices = [replace(record) for record in slices]
+
+    for index in range(1, len(output_slices) - 1):
+        if output_slices[index].quality_label != "suspicious":
+            continue
+
+        left_raw_max = raft_pair_raw_max.get((index - 1, index), 0.0)
+        right_raw_max = raft_pair_raw_max.get((index, index + 1), 0.0)
+        raft_confirmed = (
+            left_raw_max > raw_displacement_threshold
+            and right_raw_max > raw_displacement_threshold
+        )
+        phase_confirmed = (
+            allow_phase_bridge_confirmation
+            and has_phase_bridge_confirmation(index, edges)
+        )
+        if not raft_confirmed and not phase_confirmed:
+            continue
+
+        left_index = index - 1
+        right_index = index + 1
+        output_data[left_index] = replacement_source_data[left_index]
+        output_data[right_index] = replacement_source_data[right_index]
+        interpolated = (
+            replacement_source_data[left_index].astype(np.float32)
+            + replacement_source_data[right_index].astype(np.float32)
+        ) / 2.0
+        output_data[index] = np.rint(interpolated).astype(output_data.dtype)
+        output_slices[index].quality_label = "alignment_unusable"
+        output_slices[index].display_source = "interpolated"
+        output_slices[index].interpolated_from = (
+            output_slices[left_index].index,
+            output_slices[right_index].index,
+        )
+
+    return output_data, output_slices
+
+
+def phase_response_floor(edges: list[PairwiseEdge]) -> float:
+    adjacent_responses = [
+        edge.response
+        for edge in edges
+        if edge.method == "phase_correlation" and edge.j == edge.i + 1 and edge.response > 0
+    ]
+    if not adjacent_responses:
+        return PHASE_SUSPICIOUS_RESPONSE_THRESHOLD
+    return float(np.median(adjacent_responses) * PHASE_OUTLIER_RESPONSE_RATIO)
+
+
+def is_low_confidence_phase_edge(edge: PairwiseEdge, response_floor: float) -> bool:
+    return edge.method == "phase_correlation" and edge.response < response_floor
+
+
+def has_phase_bridge_confirmation(index: int, edges: list[PairwiseEdge]) -> bool:
+    left = _edge_response(edges, index - 1, index)
+    right = _edge_response(edges, index, index + 1)
+    bridge = _edge_response(edges, index - 1, index + 1)
+    if left is None or right is None or bridge is None:
+        return False
+
+    strongest_adjacent = max(left, right)
+    return (
+        bridge > 0
+        and strongest_adjacent > 0
+        and bridge >= strongest_adjacent * PHASE_BRIDGE_CONFIRMATION_RATIO
+    )
+
+
+def _edge_response(edges: list[PairwiseEdge], i: int, j: int) -> float | None:
+    for edge in edges:
+        if edge.i == i and edge.j == j:
+            return edge.response
+    return None

--- a/src/aligner/export.py
+++ b/src/aligner/export.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 import tifffile
 
-from aligner import __version__
-from aligner.models import AlignedStack, PairwiseEdge, RawStack
+from aligner.export_metadata import build_preview_stack_metadata
+from aligner.models import AlignedStack, RawStack
 
 
 def export_identity_preview_stack(stack: RawStack, output_folder: Path | str) -> None:
@@ -29,108 +29,11 @@ def export_preview_stack(stack: RawStack | AlignedStack, output_folder: Path | s
         names = ", ".join(path.name for path in existing_files)
         raise FileExistsError(f"Refusing to overwrite existing export files: {names}")
 
-    first = stack.slices[0]
-    is_aligned = isinstance(stack, AlignedStack)
-    alignment_status = stack.alignment_status if is_aligned else "identity"
     export_data = _export_data(stack)
-    export_height, export_width = export_data.shape[1:]
     for index, image in enumerate(export_data):
         tifffile.imwrite(output_path / f"slice_{index:04d}.tif", image)
 
-    metadata = {
-        "software": {
-            "name": "aligner",
-            "version": __version__,
-        },
-        "preview_stack": {
-            "alignment_status": alignment_status,
-            "slice_count": len(stack.slices),
-            "slice_spacing_nm": stack.slice_spacing_nm,
-            "image_dimensions": {
-                "width": export_width,
-                "height": export_height,
-            },
-            "dtype": first.dtype,
-        },
-        "slices": [
-            {
-                "output_file": f"slice_{index:04d}.tif",
-                "input_file": record.path,
-                "input_filename": record.filename,
-                "original_slice_index": record.index,
-                "z_nm": record.z_nm,
-                "width": record.width,
-                "height": record.height,
-                "output_width": export_width,
-                "output_height": export_height,
-                "dtype": record.dtype,
-                "alignment_status": alignment_status,
-            }
-            for index, record in enumerate(stack.slices)
-        ],
-    }
-    if is_aligned:
-        local_alignment = stack.local_alignment
-        local_method = "constrained_raft" if local_alignment is not None else "none"
-        mode = (
-            "degraded_debug"
-            if local_alignment is None or local_alignment.degraded_mode
-            else "full"
-        )
-        metadata["preview_stack"]["alignment_method"] = {
-            "coarse": "phase_correlation",
-            "local": local_method,
-            "mode": mode,
-        }
-        metadata["preview_stack"]["aligned_crop_region"] = {
-            "x": stack.crop_region.x,
-            "y": stack.crop_region.y,
-            "width": stack.crop_region.width,
-            "height": stack.crop_region.height,
-        }
-        if local_alignment is not None:
-            metadata["preview_stack"]["raft_backend"] = {
-                "name": local_alignment.backend_name,
-                "device": local_alignment.device,
-                "degraded_mode": local_alignment.degraded_mode,
-                "working_resolution_scale": local_alignment.working_scale,
-            }
-            metadata["preview_stack"]["balanced_constraints"] = {
-                "name": local_alignment.constraints.name,
-                "max_displacement_px": local_alignment.constraints.max_displacement_px,
-                "control_grid_spacing_px": local_alignment.constraints.control_grid_spacing_px,
-                "smoothing_sigma_grid": local_alignment.constraints.smoothing_sigma_grid,
-            }
-            metadata["preview_stack"]["constrained_raft_flow"] = {
-                "flow_count": local_alignment.flow_count,
-                "raw_max_displacement_px": local_alignment.raw_max_displacement_px,
-                "constrained_max_displacement_px": (
-                    local_alignment.constrained_max_displacement_px
-                ),
-                "control_grid_shape": {
-                    "height": local_alignment.control_grid_shape[0],
-                    "width": local_alignment.control_grid_shape[1],
-                },
-            }
-            if local_alignment.raft_input is not None:
-                metadata["preview_stack"]["raft_input"] = local_alignment.raft_input
-        metadata["coarse_xy_positions"] = [
-            {
-                "original_slice_index": record.index,
-                "x": x,
-                "y": y,
-            }
-            for record, (x, y) in zip(stack.slices, stack.positions, strict=True)
-        ]
-        metadata["pairwise_edges"] = [_edge_to_metadata(edge) for edge in stack.edges]
-        for slice_metadata, (x, y) in zip(metadata["slices"], stack.positions, strict=True):
-            slice_metadata["coarse_x"] = x
-            slice_metadata["coarse_y"] = y
-        for slice_metadata, record in zip(metadata["slices"], stack.slices, strict=True):
-            slice_metadata["bad_slice_status"] = record.quality_label
-            slice_metadata["display_source"] = record.display_source
-            if record.interpolated_from is not None:
-                slice_metadata["replacement_source_slices"] = list(record.interpolated_from)
+    metadata = build_preview_stack_metadata(stack, export_shape=export_data.shape[1:])
 
     (output_path / "metadata.json").write_text(
         json.dumps(metadata, indent=2) + "\n",
@@ -144,15 +47,3 @@ def _export_data(stack: RawStack | AlignedStack):
 
     crop = stack.crop_region
     return stack.data[:, crop.y : crop.y + crop.height, crop.x : crop.x + crop.width]
-
-
-def _edge_to_metadata(edge: PairwiseEdge) -> dict[str, float | int | str]:
-    return {
-        "i": edge.i,
-        "j": edge.j,
-        "dx": edge.dx,
-        "dy": edge.dy,
-        "response": edge.response,
-        "weight": edge.weight,
-        "method": edge.method,
-    }

--- a/src/aligner/export_metadata.py
+++ b/src/aligner/export_metadata.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from aligner import __version__
+from aligner.models import AlignedStack, PairwiseEdge, RawStack
+
+
+def build_preview_stack_metadata(
+    stack: RawStack | AlignedStack,
+    *,
+    export_shape: tuple[int, int],
+) -> dict[str, object]:
+    export_height, export_width = export_shape
+    first = stack.slices[0]
+    is_aligned = isinstance(stack, AlignedStack)
+    alignment_status = stack.alignment_status if is_aligned else "identity"
+
+    metadata: dict[str, object] = {
+        "software": {
+            "name": "aligner",
+            "version": __version__,
+        },
+        "preview_stack": {
+            "alignment_status": alignment_status,
+            "slice_count": len(stack.slices),
+            "slice_spacing_nm": stack.slice_spacing_nm,
+            "image_dimensions": {
+                "width": export_width,
+                "height": export_height,
+            },
+            "dtype": first.dtype,
+        },
+        "slices": [
+            {
+                "output_file": f"slice_{index:04d}.tif",
+                "input_file": record.path,
+                "input_filename": record.filename,
+                "original_slice_index": record.index,
+                "z_nm": record.z_nm,
+                "width": record.width,
+                "height": record.height,
+                "output_width": export_width,
+                "output_height": export_height,
+                "dtype": record.dtype,
+                "alignment_status": alignment_status,
+            }
+            for index, record in enumerate(stack.slices)
+        ],
+    }
+    if is_aligned:
+        _add_aligned_metadata(metadata, stack)
+    return metadata
+
+
+def _add_aligned_metadata(metadata: dict[str, object], stack: AlignedStack) -> None:
+    preview_stack = metadata["preview_stack"]
+    if not isinstance(preview_stack, dict):
+        raise TypeError("Preview Stack metadata must be a dictionary.")
+
+    local_alignment = stack.local_alignment
+    local_method = "constrained_raft" if local_alignment is not None else "none"
+    mode = (
+        "degraded_debug"
+        if local_alignment is None or local_alignment.degraded_mode
+        else "full"
+    )
+    preview_stack["alignment_method"] = {
+        "coarse": "phase_correlation",
+        "local": local_method,
+        "mode": mode,
+    }
+    preview_stack["aligned_crop_region"] = {
+        "x": stack.crop_region.x,
+        "y": stack.crop_region.y,
+        "width": stack.crop_region.width,
+        "height": stack.crop_region.height,
+    }
+    if local_alignment is not None:
+        preview_stack["raft_backend"] = {
+            "name": local_alignment.backend_name,
+            "device": local_alignment.device,
+            "degraded_mode": local_alignment.degraded_mode,
+            "working_resolution_scale": local_alignment.working_scale,
+        }
+        preview_stack["balanced_constraints"] = {
+            "name": local_alignment.constraints.name,
+            "max_displacement_px": local_alignment.constraints.max_displacement_px,
+            "control_grid_spacing_px": local_alignment.constraints.control_grid_spacing_px,
+            "smoothing_sigma_grid": local_alignment.constraints.smoothing_sigma_grid,
+        }
+        preview_stack["constrained_raft_flow"] = {
+            "flow_count": local_alignment.flow_count,
+            "raw_max_displacement_px": local_alignment.raw_max_displacement_px,
+            "constrained_max_displacement_px": (
+                local_alignment.constrained_max_displacement_px
+            ),
+            "control_grid_shape": {
+                "height": local_alignment.control_grid_shape[0],
+                "width": local_alignment.control_grid_shape[1],
+            },
+        }
+        if local_alignment.raft_input is not None:
+            preview_stack["raft_input"] = local_alignment.raft_input
+
+    metadata["coarse_xy_positions"] = [
+        {
+            "original_slice_index": record.index,
+            "x": x,
+            "y": y,
+        }
+        for record, (x, y) in zip(stack.slices, stack.positions, strict=True)
+    ]
+    metadata["pairwise_edges"] = [_edge_to_metadata(edge) for edge in stack.edges]
+
+    slices = metadata["slices"]
+    if not isinstance(slices, list):
+        raise TypeError("Slice metadata must be a list.")
+
+    for slice_metadata, (x, y) in zip(slices, stack.positions, strict=True):
+        slice_metadata["coarse_x"] = x
+        slice_metadata["coarse_y"] = y
+    for slice_metadata, record in zip(slices, stack.slices, strict=True):
+        slice_metadata["bad_slice_status"] = record.quality_label
+        slice_metadata["display_source"] = record.display_source
+        if record.interpolated_from is not None:
+            slice_metadata["replacement_source_slices"] = list(record.interpolated_from)
+
+
+def _edge_to_metadata(edge: PairwiseEdge) -> dict[str, float | int | str]:
+    return {
+        "i": edge.i,
+        "j": edge.j,
+        "dx": edge.dx,
+        "dy": edge.dy,
+        "response": edge.response,
+        "weight": edge.weight,
+        "method": edge.method,
+    }

--- a/src/aligner/image_view.py
+++ b/src/aligner/image_view.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import numpy as np
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtWidgets import QLabel
+
+
+def array_to_display_uint8(array: np.ndarray) -> np.ndarray:
+    if array.dtype == np.uint8:
+        return np.ascontiguousarray(array)
+
+    min_value = float(np.min(array))
+    max_value = float(np.max(array))
+    if max_value <= min_value:
+        return np.zeros(array.shape, dtype=np.uint8)
+
+    scaled = (array.astype(np.float32) - min_value) * (255.0 / (max_value - min_value))
+    return np.ascontiguousarray(np.clip(scaled, 0, 255).astype(np.uint8))
+
+
+def _array_to_pixmap(array: np.ndarray) -> QPixmap:
+    display = array_to_display_uint8(array)
+    height, width = display.shape
+    image = QImage(
+        display.data,
+        width,
+        height,
+        display.strides[0],
+        QImage.Format.Format_Grayscale8,
+    ).copy()
+    return QPixmap.fromImage(image)
+
+
+class ImageView(QLabel):
+    def __init__(self, title: str) -> None:
+        super().__init__(title)
+        self._title = title
+        self.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.setMinimumSize(180, 140)
+        self.setStyleSheet("background: #202124; color: #f1f3f4;")
+
+    def show_array(self, array: np.ndarray) -> None:
+        pixmap = _array_to_pixmap(array)
+        self.setPixmap(
+            pixmap.scaled(
+                self.size(),
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+        )

--- a/src/aligner/phase_alignment.py
+++ b/src/aligner/phase_alignment.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from aligner.bad_slices import (
+    is_low_confidence_phase_edge,
+    mark_phase_suspicious_slices,
+    phase_response_floor,
+)
+from aligner.models import AlignedCropRegion, AlignedStack, PairwiseEdge, RawStack
+
+
+def run_phase_alignment(stack: RawStack, *, max_pair_distance: int = 3) -> AlignedStack:
+    edges = create_phase_correlation_edges(stack, max_pair_distance=max_pair_distance)
+    positions = solve_global_positions(edges, slice_count=stack.data.shape[0])
+    data = _apply_integer_alignment(stack.data, positions)
+    height, width = stack.data.shape[1:]
+    return AlignedStack(
+        data=data,
+        slices=mark_phase_suspicious_slices(stack.slices, edges),
+        slice_spacing_nm=stack.slice_spacing_nm,
+        edges=edges,
+        positions=positions,
+        crop_region=_compute_common_valid_crop_region(
+            positions,
+            width=width,
+            height=height,
+        ),
+        xy_pixel_size_nm=stack.xy_pixel_size_nm,
+    )
+
+
+def create_phase_correlation_edges(
+    stack: RawStack,
+    *,
+    max_pair_distance: int = 3,
+) -> list[PairwiseEdge]:
+    edges: list[PairwiseEdge] = []
+    slice_count = stack.data.shape[0]
+    for distance in range(1, max_pair_distance + 1):
+        for i in range(0, slice_count - distance):
+            j = i + distance
+            dx, dy, response = _estimate_integer_shift(stack.data[i], stack.data[j])
+            edges.append(
+                PairwiseEdge(
+                    i=i,
+                    j=j,
+                    dx=dx,
+                    dy=dy,
+                    response=response,
+                    weight=response,
+                    method="phase_correlation",
+                )
+            )
+    return edges
+
+
+def solve_global_positions(
+    edges: list[PairwiseEdge],
+    *,
+    slice_count: int,
+) -> list[tuple[float, float]]:
+    if slice_count <= 0:
+        return []
+    if slice_count == 1 or not edges:
+        return [(0.0, 0.0) for _ in range(slice_count)]
+
+    x = _solve_axis(edges, slice_count=slice_count, axis="x")
+    y = _solve_axis(edges, slice_count=slice_count, axis="y")
+    return list(zip(x, y, strict=True))
+
+
+def _solve_axis(edges: list[PairwiseEdge], *, slice_count: int, axis: str) -> list[float]:
+    variable_count = slice_count - 1
+    rows: list[np.ndarray] = []
+    values: list[float] = []
+    response_floor = phase_response_floor(edges)
+
+    for edge in edges:
+        if is_low_confidence_phase_edge(edge, response_floor):
+            continue
+        weight = float(np.sqrt(max(edge.weight, 0.0)))
+        if weight == 0.0:
+            continue
+
+        row = np.zeros(variable_count, dtype=np.float64)
+        if edge.i > 0:
+            row[edge.i - 1] -= weight
+        if edge.j > 0:
+            row[edge.j - 1] += weight
+
+        rows.append(row)
+        values.append((edge.dx if axis == "x" else edge.dy) * weight)
+
+    if not rows:
+        return [0.0 for _ in range(slice_count)]
+
+    solution, *_ = np.linalg.lstsq(np.vstack(rows), np.array(values), rcond=None)
+    return [0.0, *[float(value) for value in solution]]
+
+
+def _apply_integer_alignment(
+    data: NDArray[np.integer],
+    positions: list[tuple[float, float]],
+) -> NDArray[np.integer]:
+    aligned = np.empty_like(data)
+    for index, (dx, dy) in enumerate(positions):
+        aligned[index] = np.roll(
+            data[index],
+            shift=(-int(round(dy)), -int(round(dx))),
+            axis=(0, 1),
+        )
+    return aligned
+
+
+def _compute_common_valid_crop_region(
+    positions: list[tuple[float, float]],
+    *,
+    width: int,
+    height: int,
+) -> AlignedCropRegion:
+    left = 0
+    top = 0
+    right = width
+    bottom = height
+
+    for dx, dy in positions:
+        x = int(round(dx))
+        y = int(round(dy))
+        left = max(left, 0 if x >= 0 else -x)
+        top = max(top, 0 if y >= 0 else -y)
+        right = min(right, width - x if x >= 0 else width)
+        bottom = min(bottom, height - y if y >= 0 else height)
+
+    if right <= left or bottom <= top:
+        raise ValueError("Alignment transforms have no common valid crop region.")
+
+    return AlignedCropRegion(
+        x=left,
+        y=top,
+        width=right - left,
+        height=bottom - top,
+    )
+
+
+def _estimate_integer_shift(
+    reference: NDArray[np.integer],
+    moving: NDArray[np.integer],
+) -> tuple[float, float, float]:
+    reference_fft = np.fft.fft2(reference.astype(np.float32))
+    moving_fft = np.fft.fft2(moving.astype(np.float32))
+    cross_power = moving_fft * np.conj(reference_fft)
+    magnitude = np.abs(cross_power)
+    cross_power = np.divide(
+        cross_power,
+        magnitude,
+        out=np.zeros_like(cross_power),
+        where=magnitude > 0,
+    )
+    correlation = np.abs(np.fft.ifft2(cross_power))
+    peak_y, peak_x = np.unravel_index(np.argmax(correlation), correlation.shape)
+
+    height, width = reference.shape
+    dy = peak_y - height if peak_y > height // 2 else peak_y
+    dx = peak_x - width if peak_x > width // 2 else peak_x
+    response = float(correlation[peak_y, peak_x] / np.sum(correlation))
+    return float(dx), float(dy), response

--- a/src/aligner/project_summary.py
+++ b/src/aligner/project_summary.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from aligner.models import RawStack
+
+
+def format_project_summary(stack: RawStack, *, input_folder: str | None) -> str:
+    files = [record.filename for record in stack.slices]
+    preview_names = files[:8]
+    if len(files) > len(preview_names):
+        preview_names.append(f"... {len(files) - len(preview_names)} more")
+
+    first = stack.slices[0]
+    return (
+        "Project settings\n\n"
+        f"Folder: {input_folder}\n"
+        f"Slices: {len(stack.slices)}\n"
+        f"Size: {first.width} x {first.height}\n"
+        f"Dtype: {first.dtype}\n"
+        f"Slice spacing: {stack.slice_spacing_nm:g} nm\n"
+        f"XY pixel size: {stack.xy_pixel_size_nm:g} nm\n\n"
+        "Natural file order:\n"
+        + "\n".join(preview_names)
+    )

--- a/src/aligner/raft.py
+++ b/src/aligner/raft.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 from dataclasses import dataclass
 from functools import lru_cache
 
@@ -316,6 +317,51 @@ def run_torchvision_raft_flow(
     )
 
 
+def select_raft_flow_provider(backend: str | None = None):
+    selected_backend = (
+        backend if backend is not None else os.environ.get("ALIGNER_RAFT_BACKEND", "mock")
+    )
+    selected_backend = selected_backend.strip().lower()
+    if selected_backend in {"mock", "mock_raft", "degraded"}:
+        return _run_mock_raft_flow_pair
+    if selected_backend in {"torchvision", "real", "cuda"}:
+        return _run_torchvision_raft_flow_pair
+    if selected_backend == "auto":
+        return _run_auto_raft_flow_pair
+    raise ValueError(
+        "ALIGNER_RAFT_BACKEND must be one of: mock, torchvision, auto."
+    )
+
+
+def raft_input_provenance(metadata: RaftAdapterMetadata) -> dict[str, object]:
+    return {
+        "normalization": {
+            "source_min": metadata.normalization.source_min,
+            "source_max": metadata.normalization.source_max,
+            "lower_percentile": metadata.normalization.lower_percentile,
+            "upper_percentile": metadata.normalization.upper_percentile,
+        },
+        "padding": {
+            "mode": metadata.padding.mode,
+            "multiple": metadata.padding.multiple,
+            "original_width": metadata.padding.original_width,
+            "original_height": metadata.padding.original_height,
+            "padded_width": metadata.padding.padded_width,
+            "padded_height": metadata.padding.padded_height,
+            "pad_left": metadata.padding.pad_left,
+            "pad_right": metadata.padding.pad_right,
+            "pad_top": metadata.padding.pad_top,
+            "pad_bottom": metadata.padding.pad_bottom,
+        },
+        "crop_back": {
+            "x": metadata.crop_x,
+            "y": metadata.crop_y,
+            "width": metadata.crop_width,
+            "height": metadata.crop_height,
+        },
+    }
+
+
 def normalize_stack_for_raft(
     data: NDArray[np.integer],
     *,
@@ -409,6 +455,41 @@ def _clip_flow_magnitude(
 def _max_flow_magnitude(flow: NDArray[np.float32]) -> float:
     magnitude = np.sqrt(np.sum(flow**2, axis=0))
     return float(np.max(magnitude))
+
+
+def _run_mock_raft_flow_pair(
+    stack: RawStack,
+    reference_index: int,
+    moving_index: int,
+) -> RaftFlowResult:
+    return run_mock_raft_smoke_path(
+        stack,
+        reference_index=reference_index,
+        moving_index=moving_index,
+    )
+
+
+def _run_torchvision_raft_flow_pair(
+    stack: RawStack,
+    reference_index: int,
+    moving_index: int,
+) -> RaftFlowResult:
+    return run_torchvision_raft_flow(
+        stack,
+        reference_index=reference_index,
+        moving_index=moving_index,
+    )
+
+
+def _run_auto_raft_flow_pair(
+    stack: RawStack,
+    reference_index: int,
+    moving_index: int,
+) -> RaftFlowResult:
+    try:
+        return _run_torchvision_raft_flow_pair(stack, reference_index, moving_index)
+    except TorchvisionRaftUnavailableError:
+        return _run_mock_raft_flow_pair(stack, reference_index, moving_index)
 
 
 def _import_optional_module(name: str):

--- a/src/aligner/threshold.py
+++ b/src/aligner/threshold.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import numpy as np
 from numpy.typing import NDArray
@@ -13,6 +13,39 @@ class ThresholdStatistics:
     intensity_values: NDArray[np.integer]
     histogram_counts: NDArray[np.integer]
     otsu_threshold: int
+
+
+@dataclass(slots=True)
+class ThresholdControlState:
+    statistics: ThresholdStatistics | None = None
+    pending_threshold: int | None = None
+    applied_threshold: int | None = None
+    applied_threshold_rebuilds: list[int] = field(default_factory=list)
+
+    @classmethod
+    def from_statistics(cls, statistics: ThresholdStatistics) -> ThresholdControlState:
+        threshold = statistics.otsu_threshold
+        return cls(
+            statistics=statistics,
+            pending_threshold=threshold,
+            applied_threshold=threshold,
+            applied_threshold_rebuilds=[threshold],
+        )
+
+    @classmethod
+    def unavailable(cls) -> ThresholdControlState:
+        return cls()
+
+    def set_pending(self, threshold: int) -> None:
+        self.pending_threshold = threshold
+
+    def apply_pending(self) -> int | None:
+        if self.pending_threshold is None:
+            return None
+
+        self.applied_threshold = self.pending_threshold
+        self.applied_threshold_rebuilds.append(self.applied_threshold)
+        return self.applied_threshold
 
 
 def compute_threshold_statistics(data: NDArray[np.integer]) -> ThresholdStatistics:
@@ -34,6 +67,17 @@ def compute_threshold_statistics(data: NDArray[np.integer]) -> ThresholdStatisti
         intensity_values=intensity_values,
         histogram_counts=histogram_counts,
         otsu_threshold=_otsu_threshold(histogram_counts, intensity_values),
+    )
+
+
+def format_threshold_summary(statistics: ThresholdStatistics) -> str:
+    occupied = np.flatnonzero(statistics.histogram_counts)
+    min_intensity = int(statistics.intensity_values[occupied[0]])
+    max_intensity = int(statistics.intensity_values[occupied[-1]])
+    voxel_count = int(statistics.histogram_counts.sum())
+    return (
+        f"Histogram: {voxel_count} voxels, intensity {min_intensity:g}-{max_intensity:g}; "
+        f"Otsu threshold: {statistics.otsu_threshold:g}"
     )
 
 

--- a/tests/test_app_messages.py
+++ b/tests/test_app_messages.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import numpy as np
+
+from aligner.app_messages import (
+    alignment_success_message,
+    export_label,
+    export_success_message,
+    load_success_message,
+    show_slice_message,
+)
+from aligner.models import AlignedCropRegion, AlignedStack, SliceRecord
+
+
+def test_app_messages_describe_load_alignment_and_slice_state() -> None:
+    assert load_success_message(600) == "Loaded 600 raw slices; 3D preview: Raw Stack"
+    assert alignment_success_message() == (
+        "Generated constrained RAFT Aligned Stack; 3D preview: Aligned Stack"
+    )
+    assert show_slice_message(aligned=True, slice_index=1, slice_count=3) == (
+        "Showing aligned slice 2 of 3"
+    )
+
+
+def test_export_label_tracks_export_stack_kind() -> None:
+    phase_stack = _aligned_stack("phase_only")
+    raft_stack = _aligned_stack("constrained_raft")
+
+    assert export_label(None) == "identity"
+    assert export_label(phase_stack) == "phase-only"
+    assert export_label(raft_stack) == "constrained RAFT"
+    assert export_success_message(raft_stack, "/tmp/out") == (
+        "Exported constrained RAFT Preview Stack to /tmp/out"
+    )
+
+
+def _aligned_stack(alignment_status: str) -> AlignedStack:
+    data = np.zeros((1, 2, 3), dtype=np.uint16)
+    return AlignedStack(
+        data=data,
+        slices=[
+            SliceRecord(0, "slice_0.tif", "/tmp/slice_0.tif", 0.0, 3, 2, "uint16", "raw")
+        ],
+        slice_spacing_nm=10.0,
+        edges=[],
+        positions=[(0.0, 0.0)],
+        crop_region=AlignedCropRegion(0, 0, 3, 2),
+        alignment_status=alignment_status,
+    )

--- a/tests/test_bad_slices.py
+++ b/tests/test_bad_slices.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import numpy as np
+
+from aligner.bad_slices import (
+    mark_phase_suspicious_slices,
+    replace_alignment_unusable_slices,
+)
+from aligner.models import PairwiseEdge, SliceRecord
+
+
+def test_phase_bridge_marks_middle_slice_suspicious_without_mutating_input() -> None:
+    slices = [_slice(index) for index in range(3)]
+    edges = [
+        _edge(0, 1, response=0.01),
+        _edge(1, 2, response=0.01),
+        _edge(0, 2, response=0.10),
+    ]
+
+    marked = mark_phase_suspicious_slices(slices, edges)
+
+    assert [record.quality_label for record in marked] == ["raw", "suspicious", "raw"]
+    assert [record.quality_label for record in slices] == ["raw", "raw", "raw"]
+
+
+def test_alignment_unusable_replacement_records_preview_only_provenance() -> None:
+    data = np.array(
+        [
+            [[10, 20], [30, 40]],
+            [[99, 99], [99, 99]],
+            [[20, 30], [40, 50]],
+        ],
+        dtype=np.uint16,
+    )
+    locally_aligned = np.array(data, copy=True)
+    locally_aligned[1] = 7
+    slices = [_slice(index) for index in range(3)]
+    slices[1].quality_label = "suspicious"
+
+    output_data, output_slices = replace_alignment_unusable_slices(
+        locally_aligned,
+        data,
+        slices,
+        raft_pair_raw_max={(0, 1): 9.0, (1, 2): 9.0},
+        edges=[],
+        raw_displacement_threshold=8.0,
+        allow_phase_bridge_confirmation=False,
+    )
+
+    np.testing.assert_array_equal(output_data[1], np.array([[15, 25], [35, 45]], dtype=np.uint16))
+    assert output_slices[1].quality_label == "alignment_unusable"
+    assert output_slices[1].display_source == "interpolated"
+    assert output_slices[1].interpolated_from == (0, 2)
+    assert slices[1].quality_label == "suspicious"
+
+
+def _slice(index: int) -> SliceRecord:
+    return SliceRecord(
+        index=index,
+        filename=f"slice_{index}.tif",
+        path=f"/tmp/slice_{index}.tif",
+        z_nm=float(index * 10),
+        width=2,
+        height=2,
+        dtype="uint16",
+        quality_label="raw",
+    )
+
+
+def _edge(i: int, j: int, *, response: float) -> PairwiseEdge:
+    return PairwiseEdge(
+        i=i,
+        j=j,
+        dx=0.0,
+        dy=0.0,
+        response=response,
+        weight=response,
+        method="phase_correlation",
+    )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -9,6 +9,7 @@ import tifffile
 
 from aligner.alignment import run_constrained_raft_alignment, run_phase_alignment
 from aligner.export import export_identity_preview_stack, export_preview_stack
+from aligner.export_metadata import build_preview_stack_metadata
 from aligner.models import RawStack, SliceRecord
 
 
@@ -131,6 +132,18 @@ def test_export_identity_preview_stack_writes_required_metadata(tmp_path: Path) 
             "alignment_status": "identity",
         },
     ]
+
+
+def test_preview_stack_metadata_builder_has_no_filesystem_side_effects(tmp_path: Path) -> None:
+    stack = make_raw_stack(tmp_path)
+    output_folder = tmp_path / "metadata-only"
+
+    metadata = build_preview_stack_metadata(stack, export_shape=stack.data.shape[1:])
+
+    assert not output_folder.exists()
+    assert metadata["preview_stack"]["alignment_status"] == "identity"
+    assert metadata["preview_stack"]["image_dimensions"] == {"width": 3, "height": 2}
+    assert metadata["slices"][0]["output_file"] == "slice_0000.tif"
 
 
 def test_export_phase_only_preview_stack_writes_alignment_metadata(tmp_path: Path) -> None:

--- a/tests/test_image_view.py
+++ b/tests/test_image_view.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import numpy as np
+
+from aligner.image_view import array_to_display_uint8
+
+
+def test_uint16_image_display_scaling_uses_full_display_range() -> None:
+    image = np.array([[100, 200], [300, 400]], dtype=np.uint16)
+
+    display = array_to_display_uint8(image)
+
+    assert display.dtype == np.uint8
+    assert display[0, 0] == 0
+    assert display[-1, -1] == 255
+    assert display.flags.c_contiguous
+
+
+def test_flat_image_display_scaling_returns_black_image() -> None:
+    image = np.full((2, 3), 1000, dtype=np.uint16)
+
+    display = array_to_display_uint8(image)
+
+    np.testing.assert_array_equal(display, np.zeros((2, 3), dtype=np.uint8))

--- a/tests/test_project_summary.py
+++ b/tests/test_project_summary.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import numpy as np
+
+from aligner.models import RawStack, SliceRecord
+from aligner.project_summary import format_project_summary
+
+
+def test_project_summary_reports_stack_physical_spacing_and_natural_order() -> None:
+    stack = RawStack(
+        data=np.zeros((2, 4, 5), dtype=np.uint16),
+        slices=[
+            SliceRecord(0, "slice_1.tif", "/tmp/slice_1.tif", 0.0, 5, 4, "uint16", "raw"),
+            SliceRecord(1, "slice_2.tif", "/tmp/slice_2.tif", 10.0, 5, 4, "uint16", "raw"),
+        ],
+        slice_spacing_nm=10.0,
+        xy_pixel_size_nm=25.0,
+    )
+
+    summary = format_project_summary(stack, input_folder="/tmp/input")
+
+    assert "Folder: /tmp/input" in summary
+    assert "Slices: 2" in summary
+    assert "Size: 5 x 4" in summary
+    assert "Slice spacing: 10 nm" in summary
+    assert "XY pixel size: 25 nm" in summary
+    assert "Natural file order:\nslice_1.tif\nslice_2.tif" in summary
+
+
+def test_project_summary_truncates_long_file_order_preview() -> None:
+    stack = RawStack(
+        data=np.zeros((10, 2, 3), dtype=np.uint16),
+        slices=[
+            SliceRecord(
+                index,
+                f"slice_{index}.tif",
+                f"/tmp/slice_{index}.tif",
+                float(index * 10),
+                3,
+                2,
+                "uint16",
+                "raw",
+            )
+            for index in range(10)
+        ],
+        slice_spacing_nm=10.0,
+        xy_pixel_size_nm=25.0,
+    )
+
+    summary = format_project_summary(stack, input_folder="/tmp/input")
+
+    assert "slice_7.tif" in summary
+    assert "slice_8.tif" not in summary
+    assert "... 2 more" in summary

--- a/tests/test_raft.py
+++ b/tests/test_raft.py
@@ -10,8 +10,10 @@ from aligner.raft import (
     grayscale_to_raft_tensor,
     normalize_stack_for_raft,
     pad_raft_tensor_to_multiple,
+    raft_input_provenance,
     run_mock_raft_smoke_path,
     run_torchvision_raft_flow,
+    select_raft_flow_provider,
 )
 from aligner.models import RawStack, SliceRecord
 
@@ -118,6 +120,59 @@ def test_mock_raft_smoke_path_returns_cropped_flow_and_metadata() -> None:
     assert result.metadata.crop_y == 0
     assert result.metadata.crop_width == 5
     assert result.metadata.crop_height == 3
+
+
+def test_raft_input_provenance_uses_adapter_metadata_shape() -> None:
+    data = np.stack(
+        [
+            np.arange(15, dtype=np.uint16).reshape(3, 5),
+            np.arange(15, 30, dtype=np.uint16).reshape(3, 5),
+        ],
+        axis=0,
+    )
+    stack = RawStack(
+        data=data,
+        slices=[
+            SliceRecord(0, "slice_0.tif", "/tmp/slice_0.tif", 0.0, 5, 3, "uint16", "raw"),
+            SliceRecord(1, "slice_1.tif", "/tmp/slice_1.tif", 10.0, 5, 3, "uint16", "raw"),
+        ],
+        slice_spacing_nm=10.0,
+    )
+
+    result = run_mock_raft_smoke_path(stack, reference_index=0, moving_index=1, multiple=4)
+    provenance = raft_input_provenance(result.metadata)
+
+    assert provenance["normalization"]["lower_percentile"] == 1.0
+    assert provenance["padding"]["mode"] == "reflect"
+    assert provenance["padding"]["padded_width"] == 8
+    assert provenance["crop_back"] == {"x": 0, "y": 0, "width": 5, "height": 3}
+
+
+def test_raft_backend_selection_returns_pair_provider() -> None:
+    data = np.zeros((2, 3, 5), dtype=np.uint16)
+    stack = RawStack(
+        data=data,
+        slices=[
+            SliceRecord(0, "slice_0.tif", "/tmp/slice_0.tif", 0.0, 5, 3, "uint16", "raw"),
+            SliceRecord(1, "slice_1.tif", "/tmp/slice_1.tif", 10.0, 5, 3, "uint16", "raw"),
+        ],
+        slice_spacing_nm=10.0,
+    )
+
+    provider = select_raft_flow_provider("mock")
+    result = provider(stack, 0, 1)
+
+    assert result.metadata.backend_name == "mock_raft"
+    assert result.flow.shape == (2, 3, 5)
+
+
+def test_raft_backend_selection_rejects_unknown_backend() -> None:
+    try:
+        select_raft_flow_provider("not-a-backend")
+    except ValueError as error:
+        assert "ALIGNER_RAFT_BACKEND" in str(error)
+    else:
+        raise AssertionError("Expected unknown RAFT backend error.")
 
 
 def test_constrained_raft_flow_preserves_shape_and_clips_balanced_displacement() -> None:

--- a/tests/test_threshold.py
+++ b/tests/test_threshold.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import numpy as np
 
-from aligner.threshold import compute_threshold_statistics
+from aligner.threshold import (
+    ThresholdControlState,
+    compute_threshold_statistics,
+    format_threshold_summary,
+)
 
 
 def test_threshold_statistics_use_uint8_original_intensity_units() -> None:
@@ -39,3 +43,29 @@ def test_threshold_statistics_use_uint16_original_intensity_units() -> None:
     assert stats.intensity_values[40_000] == 40_000
     assert stats.histogram_counts[40_000] == 8
     assert stats.otsu_threshold == 1_000
+
+
+def test_threshold_control_state_tracks_pending_and_applied_thresholds() -> None:
+    stats = compute_threshold_statistics(
+        np.array([[[10, 10]], [[100, 100]]], dtype=np.uint8)
+    )
+    state = ThresholdControlState.from_statistics(stats)
+
+    state.set_pending(40)
+
+    assert state.pending_threshold == 40
+    assert state.applied_threshold == 10
+    assert state.applied_threshold_rebuilds == [10]
+    assert state.apply_pending() == 40
+    assert state.applied_threshold == 40
+    assert state.applied_threshold_rebuilds == [10, 40]
+
+
+def test_threshold_summary_formats_histogram_status() -> None:
+    stats = compute_threshold_statistics(
+        np.array([[[10, 10]], [[100, 100]]], dtype=np.uint8)
+    )
+
+    assert format_threshold_summary(stats) == (
+        "Histogram: 4 voxels, intensity 10-100; Otsu threshold: 10"
+    )


### PR DESCRIPTION
## Summary

- Concentrate phase alignment, Bad Slice rules, export metadata, RAFT backend/provenance, threshold state, app messages, image display, and project summary formatting into dedicated modules.
- Keep backward-compatible alignment exports for existing callers.
- Add focused tests for each extracted module and document the architecture status in README/manual verification docs.

## Validation

- uv run pytest
- uv run ruff check .
